### PR TITLE
[🐸 Frogbot] Update version of aws-sdk to 2.814.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "start": "node helloworld"
   },
   "dependencies": {
-    "text": "0.1.0",
-    "langchain": "0.1.18",
+    "@salesforce/eslint-config-lwc": "3.7.2",
+    "aws-sdk": "^2.814.0",
     "brace-expansion": "2.0.1",
-    "ejs": "3.1.10",    
     "cookie-parse": "^0.4.0",
     "cookie-parser": "^1.4.3",
-     "aws-sdk": "^1.0.0",
-    "@salesforce/eslint-config-lwc": "3.7.2"
+    "ejs": "3.1.10",
+    "langchain": "0.1.18",
+    "text": "0.1.0"
   },
   "devDependencies": {
     "debug": "^4.1.1"


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | CVE-2020-28472 | Not Covered | aws-sdk:1.18.0 | aws-sdk 1.18.0 | [2.814.0] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | ALL |
| **Watch Name:** | morielp-1 |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | aws-sdk:1.18.0 |
| **Impacted Dependency:** | aws-sdk:1.18.0 |
| **Fixed Versions:** | [2.814.0] |
| **CVSS V3:** | 9.8 |

This affects the package @aws-sdk/shared-ini-file-loader before 1.0.0-rc.9; the package aws-sdk before 2.814.0. If an attacker submits a malicious INI file to an application that parses it with loadSharedConfigFiles , they will pollute the prototype on the application. This can be exploited further depending on the context.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
